### PR TITLE
Update import statement for bootstrap function

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm install angular2-meteor-auto-bootstrap
 
 And then import the `bootstrap` from THIS package:
 ````js
-import {bootstrap} from 'angular2-meteor-auto-bootstrap/bootstrap';
+import {bootstrap} from 'angular2-meteor-auto-bootstrap';
 ````
 
 And then just init it like any other Angular 2 application, using the `bootstrap` function:


### PR DESCRIPTION
With the statement :

``` js
import { bootstrap } from 'angular2-meteor-auto-bootstrap/bootstrap';
```

In the browser we get :

``` console
ReferenceError: Can't find variable: bootstrap
```

And in the IDE (Sublime Text v3, with Microsoft TypeScript package) :

``` console
Cannot find module ...
```

But no problem with :

``` js
import { bootstrap } from 'angular2-meteor-auto-bootstrap';
```

As described in [this tutorial](http://www.angular-meteor.com/tutorials/socially/angular2/3-way-data-binding) (section 3.4).
